### PR TITLE
feat: add try_set_offset method

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -974,10 +974,10 @@ impl<S: Data<String>> ImString<S> {
         if end < start {
             return Err(SliceError::EndBeforeStart);
         }
-        if !self.as_str().is_char_boundary(start) {
+        if !self.string.get().is_char_boundary(start) {
             return Err(SliceError::StartNotAligned);
         }
-        if !self.as_str().is_char_boundary(end) {
+        if !self.string.get().is_char_boundary(end) {
             return Err(SliceError::EndNotAligned);
         }
 


### PR DESCRIPTION
This allows changing the offset of the string so that it points to a new slice. All the bound checks are done to prevent any memory issues.